### PR TITLE
Remove timeout before refreshing after contentSaved event

### DIFF
--- a/.editorConfig
+++ b/.editorConfig
@@ -1,0 +1,7 @@
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=crlf
+
 /.yarn/**            linguist-vendored
 /.yarn/releases/*    binary
 /.yarn/plugins/**/*  binary

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 # NPM build artifacts
 artefacts/*.tgz
 !artefacts/*-dev.tgz
+
+.idea

--- a/packages/optimizely-cms-nextjs/src/ope/page.tsx
+++ b/packages/optimizely-cms-nextjs/src/ope/page.tsx
@@ -35,7 +35,6 @@ function readValueAsInt<T extends number | undefined>(variableName: string, defa
 }
 
 const defaultOptions : EditViewOptions = {
-    refreshDelay: 2000,
     refreshNotice: () => <div className='optly-refresh-notice'>Updating preview, please wait....</div>,
     errorNotice: props => <div className='optly-error-notice'>
         <div className='optly-error-title'>{ props.title }</div>
@@ -82,7 +81,7 @@ function getContentRequest(path: string | string[] = "", searchParams: Record<st
 /**
  * Create the EditPage component needed by Next.JS to render the "On Page
  * Editing" variant of the content item selected by the editor.
- * 
+ *
  * @param   dxpUrl      The domain of the CMS instance
  * @param   client      The Apollo GraphQL client to use
  * @param   factory     The component factory to be used
@@ -94,16 +93,14 @@ export function createEditPageComponent(
     options?: Partial<EditViewOptions>
 ) : EditPageComponent
 {
-    const envRefreshDelay = readValueAsInt("OPTIMIZELY_GRAPH_UPDATE_DELAY", defaultOptions.refreshDelay );
-    const { 
-        layout: PageLayout, 
-        refreshNotice: RefreshNotice, 
-        refreshDelay, 
-        errorNotice: ErrorNotice, 
+    const {
+        layout: PageLayout,
+        refreshNotice: RefreshNotice,
+        errorNotice: ErrorNotice,
         loader: getContentById,
         clientFactory,
         communicationInjectorPath
-    } = { ...defaultOptions, refreshDelay: envRefreshDelay, ...options }
+    } = { ...defaultOptions, ...options }
 
     async function EditPage({ params: { path }, searchParams }: EditPageProps) : Promise<JSX.Element>
     {
@@ -143,7 +140,7 @@ export function createEditPageComponent(
             console.log("⚪ [OnPageEdit] Requested content:", JSON.stringify(contentRequest))
             console.log("⚪ [OnPageEdit] Creating GraphQL Client:", token)
         }
-        
+
         try {
             const contentInfo = await getContentById(client, contentRequest)
             if ((contentInfo?.content?.total ?? 0) > 1) {
@@ -168,7 +165,7 @@ export function createEditPageComponent(
                 version: contentItem._metadata.version
             }
             if (context.isDebug) {
-                console.log("⚪ [OnPageEdit] Resolved content:", JSON.stringify({ 
+                console.log("⚪ [OnPageEdit] Resolved content:", JSON.stringify({
                     ...contentLink,
                     type: (contentItem.contentType ?? []).join('/')
                 }))
@@ -176,7 +173,7 @@ export function createEditPageComponent(
 
             // Store the editable content so it can be tested
             context.setEditableContentId(contentLink)
-            if (contentLink.locale) 
+            if (contentLink.locale)
                 context.setLocale(contentLink.locale)
 
             // Render the content, with edit mode context
@@ -186,7 +183,7 @@ export function createEditPageComponent(
                 {/* @ts-expect-error */}
                 <Script src={new URL(communicationInjectorPath, client.siteInfo.cmsURL).href} strategy='afterInteractive' />
                 <Layout locale={ contentItem.locale?.name ?? '' }>
-                    <OnPageEdit timeout={ refreshDelay } mode={ context.inEditMode ? 'edit' : 'preview' }>
+                    <OnPageEdit mode={ context.inEditMode ? 'edit' : 'preview' }>
                         <RefreshNotice />
                     </OnPageEdit>
                     <CmsContent contentType={ contentType } contentLink={ contentLink } fragmentData={ contentItem } />

--- a/packages/optimizely-cms-nextjs/src/ope/types.ts
+++ b/packages/optimizely-cms-nextjs/src/ope/types.ts
@@ -20,12 +20,6 @@ export type EditPageProps = {
 
 export type EditViewOptions = {
     /**
-     * The number of miliseconds to wait between receiving the 'dataSaved'
-     * event from the Optimizely CMS and actually refreshing the preview.
-     */
-    refreshDelay: number
-
-    /**
      * The message to show to the editor when awaiting the data to be updated
      * in ContentGraph
      */
@@ -53,7 +47,7 @@ export type EditViewOptions = {
     clientFactory: ClientFactory
 
     /**
-     * If provided, this allows to override the CommunicationInjector 
+     * If provided, this allows to override the CommunicationInjector
      * path.
      */
     communicationInjectorPath: string


### PR DESCRIPTION
After recent changes in CMS we no longer need any timeout. 
We can be sure that once `contentSaved` is received graph & db are already synchronized.