### PR TITLE
Simplify subscribing to changes

### DIFF
--- a/packages/optimizely-cms-nextjs/src/components/on-page-edit.tsx
+++ b/packages/optimizely-cms-nextjs/src/components/on-page-edit.tsx
@@ -3,104 +3,49 @@
 import { useState, useEffect, type FunctionComponent, type PropsWithChildren } from 'react'
 import { useRouter } from 'next/navigation.js'
 
-export type OnPageEditProps = PropsWithChildren<{
-    mode?: 'edit' | 'preview'
-    className?: string
-}>
-
-export type OptimizelyCmsContext = {
-    ready: boolean
-    inEditMode: boolean
-    isEditable: boolean
-    subscribe: (event: string, handler: (...args: any) => void) => { remove: () => void }
-}
-
-export type OptimizelyCmsContentSavedEvent = {
+type OptimizelyCmsContentSavedEvent = {
     contentLink: string,
     editUrl: string,
-    previewUrl: string
+    previewUrl: string,
+    previewToken: string
 }
 
-declare global {
-    interface Window {
-        epi?: OptimizelyCmsContext
-    }
-}
-
-export const OnPageEdit : FunctionComponent<OnPageEditProps> = ({ mode, children, className }) =>
-{
+export const OnPageEdit: FunctionComponent<PropsWithChildren> = ({ children }) => {
     const router = useRouter()
-    const [ optiCmsReady, setOptiCmsReady ] = useState<boolean>(false)
-    const [ showMask, setShowMask ] = useState<boolean>(false)
+    const [showMask, setShowMask] = useState<boolean>(false)
 
-    // Bind to the CMS & CMS Ready State
-    useEffect(() => {
-        console.log("Reading Opti CMS Context")
-        const fxCms = tryGetCms()
-        const cmsReady = fxCms?.ready ?? false
-        setOptiCmsReady(cmsReady)
-        if (!cmsReady) {
-            const cancelToken = setInterval(() => {
-                const updateCms = tryGetCms()
-                const updatedCmsReady = updateCms?.ready ?? false
-                if (updatedCmsReady) {
-                    clearInterval(cancelToken)
-                    setOptiCmsReady(updatedCmsReady)
-                }
-            }, 250)
-            return () => {
-                clearInterval(cancelToken)
-            }
+    function onContentSaved(eventData: OptimizelyCmsContentSavedEvent) {
+        const previewUrl = window.location.href
+
+        setShowMask(true)
+
+        // First: Use the updated preview URL if we have it
+        if (eventData?.previewUrl && previewUrl != eventData.previewUrl) {
+            const newUrl = new URL(eventData.previewUrl)
+            console.log(`Navigating to provided preview path: ${newUrl.pathname}${newUrl.search}`)
+            router.push(newUrl.pathname + newUrl.search)
+            // or refresh the page
+        } else {
+            console.log(`Refreshing preview: ${eventData.contentLink}`)
+            router.refresh()
         }
-    }, [])
+        setShowMask(false)
+    }
+
+    const listener = (event: any) => onContentSaved(event.detail);
 
     // Bind to the Saved event
     useEffect(() => {
-        if (!optiCmsReady)
-            return
-
-        const previewUrl = window.location.href
-
-        // Define event handler
-        function onContentSaved(eventData: OptimizelyCmsContentSavedEvent)
-        {
-            setShowMask(true)
-
-            // First: Use the updated preview URL if we have it
-            if (eventData?.previewUrl && previewUrl != eventData.previewUrl) {
-                const newUrl = new URL(eventData.previewUrl)
-                console.log(`Navigating to provided preview path: ${ newUrl.pathname }${ newUrl.search }`)
-                router.push(newUrl.pathname + newUrl.search)
-            // Third: Refresh the page
-            } else {
-                console.log(`Refreshing preview: ${ eventData.contentLink }`)
-                router.refresh()
-            }
-            setShowMask(false)
-        }
-
-        // Subscribe to event
-        console.log(`Subscribing to ContentSaved Event`)
-        const opti = tryGetCms()
-        const disposer = opti?.subscribe('contentSaved', onContentSaved)
+        window.addEventListener("optimizely:cms:contentSaved", listener);
 
         // Unsubscribe when needed
         return () => {
             console.log(`Navigating away, disabling ContentSaved event handler`)
-            disposer?.remove()
+            window.removeEventListener("optimizely:cms:contentSaved", listener)
         }
-    }, [ optiCmsReady, router ])
+    }, [router])
 
     return showMask ? children : null
-}
-
-function tryGetCms() : OptimizelyCmsContext | undefined
-{
-    try {
-        return window.epi
-    } catch {
-        return undefined
-    }
 }
 
 export default OnPageEdit

--- a/packages/optimizely-cms-nextjs/src/ope/page.tsx
+++ b/packages/optimizely-cms-nextjs/src/ope/page.tsx
@@ -117,9 +117,9 @@ export function createEditPageComponent(
                 {/* @ts-expect-error */}
                 <Script src={new URL(communicationInjectorPath, client.siteInfo.cmsURL).href} strategy='afterInteractive' />
                 <Layout locale={ contentItem.locale?.name ?? '' }>
-                    <OnPageEdit mode={ context.inEditMode ? 'edit' : 'preview' }>
+                    {context.inEditMode ?? <OnPageEdit>
                         <RefreshNotice />
-                    </OnPageEdit>
+                    </OnPageEdit>}
                     <CmsContent contentType={ contentType } contentLink={ contentLink } fragmentData={ contentItem } />
                 </Layout>
                 <div className='optly-contentLink'>ContentItem: { contentLink ? contentLinkToString(contentLink) : "Invalid content link returned from Optimizely Graph" }</div>


### PR DESCRIPTION
It is no longer necessary to wait for `window.epi` to be available
We can just subscribe using addEventListener and `optimizely:cms:contentSaved`
as the key.

Similar PR in the hello world example: https://github.com/episerver/cms-visual-builder-hello-world/pull/6/files

**IMPORTANT** Wait until SaaS-v2024.07.04.1305 is released.