### PR TITLE
Support querying variation

### DIFF
--- a/packages/optimizely-graph-functions/src/documents/queries.cms13.ts
+++ b/packages/optimizely-graph-functions/src/documents/queries.cms13.ts
@@ -1,6 +1,7 @@
 export default [
   `query getContentById($key: String!, $version: String, $locale: [Locales!], $path: String, $domain: String) {
         content: _Content(
+            variation: { include: ALL }
             where: {
                 _or: [
                     { _metadata: { key: { eq: $key }, version: { eq: $version } } }
@@ -32,6 +33,7 @@ export default [
     }`,
   `query getContentType($key: String!, $version: String, $locale: [Locales!], $path: String, $domain: String) {
         content: _Content(
+            variation: { include: ALL }
             where: {
                 _or: [
                     { _metadata: { key: { eq: $key }, version: { eq: $version } } }


### PR DESCRIPTION
By default, GraphQL queries only return items without any value in "variation" field, meaning no variation contents in the result.

This update adds support for explicitly including variations when querying by content key and version. It ensures variation content is returned when intended.