### PR TITLE
Add support for vercel environment variables to graph client

### DIFF
--- a/packages/optimizely-graph-cli/src/commands/unpublish.ts
+++ b/packages/optimizely-graph-cli/src/commands/unpublish.ts
@@ -2,7 +2,7 @@ import { getArgsConfig, getFrontendURL } from "../config.js";
 import type { CliModule } from '../types.js';
 import createAdminApi, { isApiError } from '@remkoj/optimizely-graph-client/admin'
 
-type PublishToVercelProps = { path: string, token_id: string, publish_token: string }
+type PublishToVercelProps = { path: string, token_id: string, publish_token: string, vercel_automation_bypass: string }
 
 /**
  * An Yargs Command module
@@ -22,6 +22,7 @@ export const publishToVercelModule: CliModule<PublishToVercelProps> = {
     const hookPath = args.path ?? '/'
     const token = args.publish_token
     const token_id = args.token_id
+    const vercelAutomationBypass = args.vercel_automation_bypass
 
     // Create secure client
     if (!cgConfig.app_key || !cgConfig.secret)
@@ -53,6 +54,8 @@ export const publishToVercelModule: CliModule<PublishToVercelProps> = {
     const webhookTarget = new URL(hookPath, frontendUrl)
     if (token)
       webhookTarget.searchParams.set('token', token)
+    if (vercelAutomationBypass)
+      webhookTarget.searchParams.set('x-vercel-protection-bypass', vercelAutomationBypass)
     process.stdout.write(`Removing webhook target: ${webhookTarget.href}\n`)
     if (webhookTarget.hostname == 'localhost') {
       process.stderr.write("!! Cannot register a localhost Site URL with Content Graph\n")
@@ -104,6 +107,7 @@ export const publishToVercelModule: CliModule<PublishToVercelProps> = {
     args.positional('path', { type: "string", describe: "The frontend route to invoke to publish", default: "/api/content/publish", demandOption: false })
     args.option("publish_token", { alias: "pt", description: "Publishing token", string: true, type: "string", demandOption: !hasDefaultToken, default: defaultToken })
     args.option("token_id", { alias: "ti", description: "If set, removes this webhook only", string: true, type: "string", demandOption: false, default: undefined })
+    args.option("vercel_automation_bypass", { type: "string", description: "Token used for automation to bypass vercel password protection", demandOption: false, default: undefined });
     return args
   }
 }

--- a/packages/optimizely-graph-client/src/config.ts
+++ b/packages/optimizely-graph-client/src/config.ts
@@ -42,6 +42,17 @@ export function readEnvironmentVariables(): Types.OptimizelyGraphConfig {
   return config
 }
 
+export function readVercelEnvironmentVariables(): Types.VercelEnvironmentVariables {
+  const config: Types.VercelEnvironmentVariables = {
+    automation_bypass_secret: getOptional('VERCEL_AUTOMATION_BYPASS_SECRET'),
+    target_env: getOptional('VERCEL_TARGET_ENV'),
+    project_production_url: getOptional('VERCEL_PROJECT_PRODUCTION_URL'),
+    branch_url: getOptional('VERCEL_BRANCH_URL')
+  }
+  
+  return config
+}  
+
 export function applyConfigDefaults(configuredValues: Types.OptimizelyGraphConfig): Types.OptimizelyGraphConfigInternal {
   const defaults: Types.OptimizelyGraphConfigInternal = {
     single_key: "",
@@ -75,9 +86,9 @@ function resolveDeploymentDomain(): string | undefined {
     return opti_variables
 
   // Then try to resolve based upon Vercel environment variables
-  const vercelEnv = getOptional('VERCEL_TARGET_ENV')
+  const vercelEnv = readVercelEnvironmentVariables().target_env
   if (vercelEnv && vercelEnv != 'development') {
-    const vercelDomain = vercelEnv == 'production' ? getOptional('VERCEL_PROJECT_PRODUCTION_URL') : getOptional('VERCEL_BRANCH_URL');
+    const vercelDomain = vercelEnv == 'production' ? readVercelEnvironmentVariables().project_production_url : readVercelEnvironmentVariables().branch_url;
     if (vercelDomain && vercelDomain != "")
       return vercelDomain
   }

--- a/packages/optimizely-graph-client/src/types.ts
+++ b/packages/optimizely-graph-client/src/types.ts
@@ -65,6 +65,16 @@ export type OptimizelyGraphConfigInternal = {
 export type OptimizelyGraphConfig = Partial<Omit<OptimizelyGraphConfigInternal, 'single_key'>> & Pick<OptimizelyGraphConfigInternal, 'single_key'>
 
 /**
+ * See [Vercel docs](https://vercel.com/docs/environment-variables/system-environment-variables) for details
+ */
+export type VercelEnvironmentVariables = {
+    automation_bypass_secret?: string
+    target_env?: string
+    project_production_url?: string
+    branch_url?: string
+}
+
+/**
  * @deprecated Reference OptimizelyGraphConfig
  */
 export type ContentGraphConfig = OptimizelyGraphConfig


### PR DESCRIPTION
This change is motivated by the need to add the vercel automation bypass token to webhook urls registered on preproduction, password protected vercel environments.
- The webhook create function automatically picks up and uses the token via the vercel environment variable if available or, following the existing convention, it can be specified in the CLI command.
- The token can be specified in the CLI command for the webhook delete function but it is not automatically picked up there.
- New `readVercelEnvironmentVariables` function added to `optimizely-graph-client` package to facilitate retrieving the automation bypass token as well as a few other in use.