### PR TITLE
Update ContentBaseType enum with preview3 base types

### DIFF
--- a/packages/optimizely-cms-api/src/enums.ts
+++ b/packages/optimizely-cms-api/src/enums.ts
@@ -4,15 +4,15 @@
  * @deprecated Only retained here for compatibility
  */
 export enum ContentBaseType {
-    PAGE = 'page',
-    COMPONENT = 'component',
-    MEDIA = 'media',
-    IMAGE = 'image',
-    VIDEO = 'video',
-    FOLDER = 'folder',
-    EXPERIENCE = 'experience',
-    SECTION = 'section',
-    ELEMENT = 'element',
+    PAGE = '_page',
+    COMPONENT = '_component',
+    MEDIA = '_media',
+    IMAGE = '_image',
+    VIDEO = '_video',
+    FOLDER = '_folder',
+    EXPERIENCE = '_experience',
+    SECTION = '_section',
+    ELEMENT = '_element',
 }
 
 /**


### PR DESCRIPTION
Current behavior, the scripts discard all content types pulled from the CMS, because of "unsupported base type":

```
→ Removing globalcontract:_Metadata as it has an unsupported base type: _component
→ Removing globalcontract:_Item as it has an unsupported base type: default
→ Removing globalcontract:_AssetMetadata as it has an unsupported base type: _component
→ Removing globalcontract:_AssetItem as it has an unsupported base type: default
→ Removing globalcontract:_ImageMetadata as it has an unsupported base type: _component
→ Removing globalcontract:_ImageItem as it has an unsupported base type: default
→ Removing BlankExperience as it has an unsupported base type: _experience
→ Removing BlankSection as it has an unsupported base type: _section
→ Removing TextComponent as it has an unsupported base type: _component
→ Removing GenericMedia as it has an unsupported base type: _media
→ Removing ImageMedia as it has an unsupported base type: _image
→ Removing VideoMedia as it has an unsupported base type: _video
→ Removing SysContentFolder as it has an unsupported base type: _folder
→ Applied content type filters, reduced from 13 to 0 items
```

While you can work past the issue by specifying base types in the command, this should update the base types to align with preview3 API expectations.