### PR TITLE
CMS-50805 Fix hardcoded API endpoints and enhance configuration for CMS URLs

### DIFF
--- a/packages/optimizely-cms-api/src/api-client.ts
+++ b/packages/optimizely-cms-api/src/api-client.ts
@@ -18,13 +18,14 @@ export class ApiClient extends CmsIntegrationApiClient
     public constructor (config?: CmsIntegrationApiOptions)
     {
         const options = config ?? getCmsIntegrationApiConfigFromEnvironment()
-        let base = OpenAPI.BASE;
+        let base = options.base.toString();
         let version = OpenAPI.VERSION;
         if (options.cmsVersion == OptiCmsVersion.CMS12) {
-          base = options.base.toString();
           version = 'preview1';
           if (options.debug)
-            console.info(`🚧 Switched to CMS 12 compatibility mode. Overridden Base URL ${base}, version: ${ version }`);
+            console.info(`🚧 CMS 12 compatibility mode. Base URL ${base}, version: ${ version }`);
+        } else if (options.debug) {
+          console.info(`🚀 CMS 13 mode. Base URL ${base}, version: ${ version }`);
         }
         let access_token : string | undefined = undefined
         super({

--- a/packages/optimizely-cms-api/src/config.ts
+++ b/packages/optimizely-cms-api/src/config.ts
@@ -2,16 +2,16 @@ import { OpenAPI } from './client/core/OpenAPI'
 import { OptiCmsVersion } from './types'
 
 export type CmsIntegrationApiOptions = {
-  base: URL
-  clientId?: string
-  clientSecret?: string
-  actAs?: string
-  debug?: boolean
+    base: URL
+    clientId?: string
+    clientSecret?: string
+    actAs?: string
+    debug?: boolean
 
-  /**
-   * The CMS Schema version that is used
-   */
-  cmsVersion?: OptiCmsVersion
+    /**
+     * The CMS Schema version that is used
+     */
+    cmsVersion?: OptiCmsVersion
 }
 
 /**
@@ -20,113 +20,104 @@ export type CmsIntegrationApiOptions = {
  * @param cmsUrl - The CMS frontend URL
  * @returns The API gateway URL, or null if not a recognized SaaS pattern
  */
-function extractApiGateway(cmsUrl: string): string | null {
-  try {
-    const urlObj = new URL(cmsUrl)
-    const hostname = urlObj.hostname
+function extractApiGateway(cmsUrl: string): string | null
+{
+    try {
+        const urlObj = new URL(cmsUrl)
+        const hostname = urlObj.hostname
 
-    // Check if it's a SaaS CMS URL pattern: app[-tenant].cms[env].optimizely.com
-    const saasMatch = hostname.match(
-      /^app(-[^.]+)?\.cms([^.]*)?\.optimizely\.com$/
-    )
-    if (saasMatch) {
-      // Extract only the environment suffix (not tenant)
-      // e.g., 'test' from '.cmstest.' or '' from '.cms.'
-      const env = saasMatch[2] || ''
+        // Check if it's a SaaS CMS URL pattern: app[-tenant].cms[env].optimizely.com
+        const saasMatch = hostname.match(/^app(-[^.]+)?\.cms([^.]*)?\.optimizely\.com$/)
+        if (saasMatch) {
+            // Extract only the environment suffix (not tenant)
+            // e.g., 'test' from '.cmstest.' or '' from '.cms.'
+            const env = saasMatch[2] || ''
 
-      // Construct API gateway: api.cms[env].optimizely.com (no tenant in API URL)
-      return `https://api.cms${env}.optimizely.com`
+            // Construct API gateway: api.cms[env].optimizely.com (no tenant in API URL)
+            return `https://api.cms${env}.optimizely.com`
+        }
+
+        return null
+    } catch {
+        return null
+    }
+}
+
+export function getCmsIntegrationApiConfigFromEnvironment() : CmsIntegrationApiOptions
+{
+    const cmsUrl = getOptional('OPTIMIZELY_CMS_URL', 'https://example.cms.optimizely.com')
+    const cmsApiUrl = getOptional('OPTIMIZELY_CMS_API_URL')
+    const clientId = getMandatory('OPTIMIZELY_CMS_CLIENT_ID')
+    const clientSecret = getMandatory('OPTIMIZELY_CMS_CLIENT_SECRET')
+    const actAs = getOptional('OPTIMIZELY_CMS_USER_ID')
+    const debug = getOptional('OPTIMIZELY_DEBUG',"0") == "1"
+    const cmsVersion = getSelection<OptiCmsVersion>('OPTIMIZELY_CMS_SCHEMA', [OptiCmsVersion.CMS12,OptiCmsVersion.CMS13], OptiCmsVersion.CMS13)
+
+    let baseUrl : URL
+    try {
+        const cmsUrlAdjusted = cmsUrl.includes("://") ? cmsUrl : 'https://'+cmsUrl
+
+        // Determine the API endpoint URL
+        let apiEndpoint: string
+        if (cmsApiUrl) {
+            // User explicitly set the API URL
+            apiEndpoint = cmsApiUrl.includes("://") ? cmsApiUrl : 'https://'+cmsApiUrl
+        } else {
+            // Try to auto-detect API gateway from CMS URL
+            const detectedApiGateway = extractApiGateway(cmsUrlAdjusted)
+            if (detectedApiGateway) {
+                apiEndpoint = detectedApiGateway
+            } else {
+                // Custom domain or non-SaaS: use the CMS URL as-is
+                apiEndpoint = cmsUrlAdjusted
+            }
+        }
+
+        const apiPath = new URL(OpenAPI.BASE).pathname
+        baseUrl = new URL(apiPath, apiEndpoint)
+        if (cmsVersion == OptiCmsVersion.CMS12)
+            baseUrl.pathname = baseUrl.pathname.replace('preview2', 'preview1')
+    } catch (e) {
+        throw new Error("Invalid Optimizely CMS URL provided")
     }
 
-    return null
-  } catch {
-    return null
-  }
-}
-
-export function getCmsIntegrationApiConfigFromEnvironment(): CmsIntegrationApiOptions {
-  const cmsUrl = getOptional(
-    'OPTIMIZELY_CMS_URL',
-    'https://example.cms.optimizely.com'
-  )
-  const cmsApiUrl = getOptional('OPTIMIZELY_CMS_API_URL')
-  const clientId = getMandatory('OPTIMIZELY_CMS_CLIENT_ID')
-  const clientSecret = getMandatory('OPTIMIZELY_CMS_CLIENT_SECRET')
-  const actAs = getOptional('OPTIMIZELY_CMS_USER_ID')
-  const debug = getOptional('OPTIMIZELY_DEBUG', '0') == '1'
-  const cmsVersion = getSelection<OptiCmsVersion>(
-    'OPTIMIZELY_CMS_SCHEMA',
-    [OptiCmsVersion.CMS12, OptiCmsVersion.CMS13],
-    OptiCmsVersion.CMS13
-  )
-
-  let baseUrl: URL
-  try {
-    const cmsUrlAdjusted = cmsUrl.includes('://') ? cmsUrl : 'https://' + cmsUrl
-
-    // Determine the API endpoint URL
-    let apiEndpoint: string
-    if (cmsApiUrl) {
-      // User explicitly set the API URL
-      apiEndpoint = cmsApiUrl.includes('://')
-        ? cmsApiUrl
-        : 'https://' + cmsApiUrl
-    } else {
-      // Try to auto-detect API gateway from CMS URL
-      const detectedApiGateway = extractApiGateway(cmsUrlAdjusted)
-      if (detectedApiGateway) {
-        apiEndpoint = detectedApiGateway
-      } else {
-        // Custom domain or non-SaaS: use the CMS URL as-is
-        apiEndpoint = cmsUrlAdjusted
-      }
+    if (debug) {
+        console.log(`[Optimizely CMS API] CMS URL: ${ cmsUrl }`)
+        console.log(`[Optimizely CMS API] API Endpoint: ${ baseUrl }`)
+        console.log(`[Optimizely CMS API] Connecting to ${ baseUrl } as ${ clientId }`)
     }
 
-    const apiPath = new URL(OpenAPI.BASE).pathname
-    baseUrl = new URL(apiPath, apiEndpoint)
-    if (cmsVersion == OptiCmsVersion.CMS12)
-      baseUrl.pathname = baseUrl.pathname.replace('preview2', 'preview1')
-  } catch (e) {
-    throw new Error('Invalid Optimizely CMS URL provided')
-  }
-
-  if (debug) {
-    console.log(`[Optimizely CMS API] Connecting to ${baseUrl} as ${clientId}`)
-  }
-
-  return {
-    base: baseUrl,
-    clientId,
-    clientSecret,
-    actAs,
-    debug,
-    cmsVersion,
-  }
+    return {
+        base: baseUrl,
+        clientId,
+        clientSecret,
+        actAs,
+        debug,
+        cmsVersion
+    }
 }
 
-function getOptional<DT extends string | undefined>(
-  variable: string,
-  defaultValue?: DT
-): DT extends string ? string : string | undefined {
-  const envValue = process.env[variable]
-  if (!envValue || envValue == '')
-    return defaultValue as DT extends string ? string : undefined
-  return envValue
+function getOptional<DT extends string | undefined>(variable: string, defaultValue?: DT) : DT extends string ? string : string | undefined
+{
+    const envValue = process.env[variable]
+    if (!envValue || envValue == "")
+        return defaultValue as DT extends string ? string : undefined
+    return envValue
 }
-function getMandatory(variable: string): string {
-  const envValue = process.env[variable]
-  if (!envValue)
-    throw new Error(`The environment variable ${variable} is missing or empty`)
-  return envValue
+function getMandatory(variable: string) : string
+{
+    const envValue = process.env[variable]
+    if (!envValue)
+        throw new Error(`The environment variable ${ variable } is missing or empty`)
+    return envValue
 }
 
-function getSelection<T>(
-  envVarName: string,
-  allowedValues: T[],
-  defaultValue: T
-): T {
-  const rawValue = getOptional(envVarName, defaultValue as string)
-  if (!rawValue) return defaultValue
-  if (allowedValues.some((av) => av == rawValue)) return rawValue as T
-  return defaultValue
+function getSelection<T>(envVarName: string, allowedValues: T[], defaultValue: T) : T
+{
+    const rawValue = getOptional(envVarName, defaultValue as string)
+    if (!rawValue)
+        return defaultValue
+    if (allowedValues.some(av => av == rawValue))
+        return rawValue as T
+    return defaultValue
 }

--- a/packages/optimizely-cms-api/src/config.ts
+++ b/packages/optimizely-cms-api/src/config.ts
@@ -14,35 +14,6 @@ export type CmsIntegrationApiOptions = {
     cmsVersion?: OptiCmsVersion
 }
 
-/**
- * Extracts the API gateway URL from a CMS frontend URL.
- * Converts patterns like app-xyz.cmstest.optimizely.com → api.cmstest.optimizely.com
- * @param cmsUrl - The CMS frontend URL
- * @returns The API gateway URL, or null if not a recognized SaaS pattern
- */
-function extractApiGateway(cmsUrl: string): string | null
-{
-    try {
-        const urlObj = new URL(cmsUrl)
-        const hostname = urlObj.hostname
-
-        // Check if it's a SaaS CMS URL pattern: app[-tenant].cms[env].optimizely.com
-        const saasMatch = hostname.match(/^app(-[^.]+)?\.cms([^.]*)?\.optimizely\.com$/)
-        if (saasMatch) {
-            // Extract only the environment suffix (not tenant)
-            // e.g., 'test' from '.cmstest.' or '' from '.cms.'
-            const env = saasMatch[2] || ''
-
-            // Construct API gateway: api.cms[env].optimizely.com (no tenant in API URL)
-            return `https://api.cms${env}.optimizely.com`
-        }
-
-        return null
-    } catch {
-        return null
-    }
-}
-
 export function getCmsIntegrationApiConfigFromEnvironment() : CmsIntegrationApiOptions
 {
     const cmsUrl = getOptional('OPTIMIZELY_CMS_URL', 'https://example.cms.optimizely.com')
@@ -81,11 +52,8 @@ export function getCmsIntegrationApiConfigFromEnvironment() : CmsIntegrationApiO
         throw new Error("Invalid Optimizely CMS URL provided")
     }
 
-    if (debug) {
-        console.log(
-          `[Optimizely CMS API] Connecting to ${baseUrl} as ${clientId}`
-        )
-    }
+    if (debug)
+        console.log(`[Optimizely CMS API] Connecting to ${ baseUrl } as ${ clientId }`)
 
     return {
         base: baseUrl,
@@ -104,7 +72,7 @@ function getOptional<DT extends string | undefined>(variable: string, defaultVal
         return defaultValue as DT extends string ? string : undefined
     return envValue
 }
-function getMandatory(variable: string) : string
+function getMandatory(variable: string) : string 
 {
     const envValue = process.env[variable]
     if (!envValue)
@@ -120,4 +88,34 @@ function getSelection<T>(envVarName: string, allowedValues: T[], defaultValue: T
     if (allowedValues.some(av => av == rawValue))
         return rawValue as T
     return defaultValue
+}
+
+
+/**
+ * Extracts the API gateway URL from a CMS frontend URL.
+ * Converts patterns like app-xyz.cmstest.optimizely.com → api.cmstest.optimizely.com
+ * @param cmsUrl - The CMS frontend URL
+ * @returns The API gateway URL, or null if not a recognized SaaS pattern
+ */
+function extractApiGateway(cmsUrl: string): string | null
+{
+    try {
+        const urlObj = new URL(cmsUrl)
+        const hostname = urlObj.hostname
+
+        // Check if it's a SaaS CMS URL pattern: app[-tenant].cms[env].optimizely.com
+        const saasMatch = hostname.match(/^app(-[^.]+)?\.cms([^.]*)?\.optimizely\.com$/)
+        if (saasMatch) {
+            // Extract only the environment suffix (not tenant)
+            // e.g., 'test' from '.cmstest.' or '' from '.cms.'
+            const env = saasMatch[2] || ''
+
+            // Construct API gateway: api.cms[env].optimizely.com (no tenant in API URL)
+            return `https://api.cms${env}.optimizely.com`
+        }
+
+        return null
+    } catch {
+        return null
+    }
 }

--- a/packages/optimizely-cms-api/src/config.ts
+++ b/packages/optimizely-cms-api/src/config.ts
@@ -2,71 +2,131 @@ import { OpenAPI } from './client/core/OpenAPI'
 import { OptiCmsVersion } from './types'
 
 export type CmsIntegrationApiOptions = {
-    base: URL
-    clientId?: string
-    clientSecret?: string
-    actAs?: string
-    debug?: boolean
+  base: URL
+  clientId?: string
+  clientSecret?: string
+  actAs?: string
+  debug?: boolean
 
-    /**
-     * The CMS Schema version that is used
-     */
-    cmsVersion?: OptiCmsVersion
+  /**
+   * The CMS Schema version that is used
+   */
+  cmsVersion?: OptiCmsVersion
 }
 
-export function getCmsIntegrationApiConfigFromEnvironment() : CmsIntegrationApiOptions
-{
-    const cmsUrl = getOptional('OPTIMIZELY_CMS_URL', 'https://example.cms.optimizely.com')
-    const clientId = getMandatory('OPTIMIZELY_CMS_CLIENT_ID')
-    const clientSecret = getMandatory('OPTIMIZELY_CMS_CLIENT_SECRET')
-    const actAs = getOptional('OPTIMIZELY_CMS_USER_ID')
-    const debug = getOptional('OPTIMIZELY_DEBUG',"0") == "1"
-    const cmsVersion = getSelection<OptiCmsVersion>('OPTIMIZELY_CMS_SCHEMA', [OptiCmsVersion.CMS12,OptiCmsVersion.CMS13], OptiCmsVersion.CMS13)
+/**
+ * Extracts the API gateway URL from a CMS frontend URL.
+ * Converts patterns like app-xyz.cmstest.optimizely.com → api.cmstest.optimizely.com
+ * @param cmsUrl - The CMS frontend URL
+ * @returns The API gateway URL, or null if not a recognized SaaS pattern
+ */
+function extractApiGateway(cmsUrl: string): string | null {
+  try {
+    const urlObj = new URL(cmsUrl)
+    const hostname = urlObj.hostname
 
-    let baseUrl : URL
-    try {
-        const cmsUrlAdjusted = cmsUrl.includes("://") ? cmsUrl : 'https://'+cmsUrl
-        baseUrl = new URL(OpenAPI.BASE, cmsUrlAdjusted)
-        if (cmsVersion == OptiCmsVersion.CMS12)
-            baseUrl.pathname = baseUrl.pathname.replace('preview2', 'preview1')
-    } catch (e) {
-        throw new Error("Invalid Optimizely CMS URL provided")
+    // Check if it's a SaaS CMS URL pattern: app[-tenant].cms[env].optimizely.com
+    const saasMatch = hostname.match(
+      /^app(-[^.]+)?\.cms([^.]*)?\.optimizely\.com$/
+    )
+    if (saasMatch) {
+      // Extract only the environment suffix (not tenant)
+      // e.g., 'test' from '.cmstest.' or '' from '.cms.'
+      const env = saasMatch[2] || ''
+
+      // Construct API gateway: api.cms[env].optimizely.com (no tenant in API URL)
+      return `https://api.cms${env}.optimizely.com`
     }
 
-    if (debug)
-        console.log(`[Optimizely CMS API] Connecting to ${ baseUrl } as ${ clientId }`)
+    return null
+  } catch {
+    return null
+  }
+}
 
-    return {
-        base: baseUrl,
-        clientId,
-        clientSecret,
-        actAs,
-        debug,
-        cmsVersion
+export function getCmsIntegrationApiConfigFromEnvironment(): CmsIntegrationApiOptions {
+  const cmsUrl = getOptional(
+    'OPTIMIZELY_CMS_URL',
+    'https://example.cms.optimizely.com'
+  )
+  const cmsApiUrl = getOptional('OPTIMIZELY_CMS_API_URL')
+  const clientId = getMandatory('OPTIMIZELY_CMS_CLIENT_ID')
+  const clientSecret = getMandatory('OPTIMIZELY_CMS_CLIENT_SECRET')
+  const actAs = getOptional('OPTIMIZELY_CMS_USER_ID')
+  const debug = getOptional('OPTIMIZELY_DEBUG', '0') == '1'
+  const cmsVersion = getSelection<OptiCmsVersion>(
+    'OPTIMIZELY_CMS_SCHEMA',
+    [OptiCmsVersion.CMS12, OptiCmsVersion.CMS13],
+    OptiCmsVersion.CMS13
+  )
+
+  let baseUrl: URL
+  try {
+    const cmsUrlAdjusted = cmsUrl.includes('://') ? cmsUrl : 'https://' + cmsUrl
+
+    // Determine the API endpoint URL
+    let apiEndpoint: string
+    if (cmsApiUrl) {
+      // User explicitly set the API URL
+      apiEndpoint = cmsApiUrl.includes('://')
+        ? cmsApiUrl
+        : 'https://' + cmsApiUrl
+    } else {
+      // Try to auto-detect API gateway from CMS URL
+      const detectedApiGateway = extractApiGateway(cmsUrlAdjusted)
+      if (detectedApiGateway) {
+        apiEndpoint = detectedApiGateway
+      } else {
+        // Custom domain or non-SaaS: use the CMS URL as-is
+        apiEndpoint = cmsUrlAdjusted
+      }
     }
+
+    const apiPath = new URL(OpenAPI.BASE).pathname
+    baseUrl = new URL(apiPath, apiEndpoint)
+    if (cmsVersion == OptiCmsVersion.CMS12)
+      baseUrl.pathname = baseUrl.pathname.replace('preview2', 'preview1')
+  } catch (e) {
+    throw new Error('Invalid Optimizely CMS URL provided')
+  }
+
+  if (debug) {
+    console.log(`[Optimizely CMS API] Connecting to ${baseUrl} as ${clientId}`)
+  }
+
+  return {
+    base: baseUrl,
+    clientId,
+    clientSecret,
+    actAs,
+    debug,
+    cmsVersion,
+  }
 }
 
-function getOptional<DT extends string | undefined>(variable: string, defaultValue?: DT) : DT extends string ? string : string | undefined
-{
-    const envValue = process.env[variable]
-    if (!envValue || envValue == "")
-        return defaultValue as DT extends string ? string : undefined
-    return envValue
+function getOptional<DT extends string | undefined>(
+  variable: string,
+  defaultValue?: DT
+): DT extends string ? string : string | undefined {
+  const envValue = process.env[variable]
+  if (!envValue || envValue == '')
+    return defaultValue as DT extends string ? string : undefined
+  return envValue
 }
-function getMandatory(variable: string) : string 
-{
-    const envValue = process.env[variable]
-    if (!envValue)
-        throw new Error(`The environment variable ${ variable } is missing or empty`)
-    return envValue
+function getMandatory(variable: string): string {
+  const envValue = process.env[variable]
+  if (!envValue)
+    throw new Error(`The environment variable ${variable} is missing or empty`)
+  return envValue
 }
 
-function getSelection<T>(envVarName: string, allowedValues: T[], defaultValue: T) : T
-{
-    const rawValue = getOptional(envVarName, defaultValue as string)
-    if (!rawValue)
-        return defaultValue
-    if (allowedValues.some(av => av == rawValue))
-        return rawValue as T
-    return defaultValue
+function getSelection<T>(
+  envVarName: string,
+  allowedValues: T[],
+  defaultValue: T
+): T {
+  const rawValue = getOptional(envVarName, defaultValue as string)
+  if (!rawValue) return defaultValue
+  if (allowedValues.some((av) => av == rawValue)) return rawValue as T
+  return defaultValue
 }

--- a/packages/optimizely-cms-api/src/config.ts
+++ b/packages/optimizely-cms-api/src/config.ts
@@ -82,9 +82,9 @@ export function getCmsIntegrationApiConfigFromEnvironment() : CmsIntegrationApiO
     }
 
     if (debug) {
-        console.log(`[Optimizely CMS API] CMS URL: ${ cmsUrl }`)
-        console.log(`[Optimizely CMS API] API Endpoint: ${ baseUrl }`)
-        console.log(`[Optimizely CMS API] Connecting to ${ baseUrl } as ${ clientId }`)
+        console.log(
+          `[Optimizely CMS API] Connecting to ${baseUrl} as ${clientId}`
+        )
     }
 
     return {

--- a/packages/optimizely-cms-api/src/getaccesstoken.ts
+++ b/packages/optimizely-cms-api/src/getaccesstoken.ts
@@ -17,7 +17,7 @@ export async function getAccessToken(config?: CmsIntegrationApiOptions) : Promis
     let authUrl = options.cmsVersion === OptiCmsVersion.CMS12 ? (() => {
       let u = new URL(`${ OpenAPI.BASE }/oauth/token`, options.base).href;
       return u.replace('preview2', 'preview1');
-    })() : new URL('/oauth/token', OpenAPI.BASE).href;
+    })() : new URL('/oauth/token', options.base).href;
     const headers = new Headers()
 
     headers.append('Authorization', `Basic ${ base64Encode(`${ options.clientId }:${ options.clientSecret }`)}`)


### PR DESCRIPTION
- Remove hardcoded gateway endpoint.
- Introduce `extractApiGateway` to check if the CMS SaaS url should point to `cms` or `cmstest` (for testers this will be vital).
- Introduce `OPTIMIZELY_CMS_API_URL` for manually specifying gateway endpoint. 