### PR TITLE
Update getContentByPath to check both simple address path and hierarchical path

### DIFF
--- a/packages/optimizely-graph-functions/src/documents/queries.cms13.ts
+++ b/packages/optimizely-graph-functions/src/documents/queries.cms13.ts
@@ -27,10 +27,10 @@ export default [
   `query getContentByPath($path: [String!]!, $locale: [Locales!], $siteId: String, $changeset: String = null) {
       content: _Content(
         where: {
-          _metadata: {
-            url: { default: { in: $path }, base: { eq: $siteId } }
-            changeset: { eq: $changeset }
-          }
+          _or: [
+              { _metadata: { url: { default: { in: $path }, base: { eq: $siteId } }, changeset: { eq: $changeset } } }
+              { _metadata: { url: { hierarchical: { in: $path }, type: { eq: "SIMPLE" }, base: { eq: $siteId } }, changeset: { eq: $changeset } } }
+          ]
         }
         locale: $locale
       ) {


### PR DESCRIPTION
**Related issue:** https://github.com/remkoj/optimizely-dxp-clients/issues/109

**Updates:**

Update the `getContentByPath` query to check both default and hierarchical paths when dealing with `SIMPLE` URL types. This ensures that if the item matches by default URL, it passes, if it doesn't, it checks if the page is a `SIMPLE` type and matches via the hierarchical path.