### PR TITLE
Fix:  Import paths not correct when generated on Windows machine

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/nextjs_factories.ts
+++ b/packages/optimizely-cms-cli/src/commands/nextjs_factories.ts
@@ -80,8 +80,8 @@ export const NextJsFactoryCommand : NextJsModule = {
         // Build factory / component structure
         const componentFactoryDefintions = new Map<string, ComponentFactoryDefintion>()
         components.forEach(component => {
-            const componentDir = path.dirname(path.join(...component));
-            const componentFile = path.basename(path.join(...component));
+            const componentDir = path.dirname(path.posix.join(...component));
+            const componentFile = path.basename(path.posix.join(...component));
 
             // Determine component target
             const componentKey = getComponentKey(component, basePath)
@@ -245,7 +245,7 @@ function processName(input: string) : string {
 function generateFactory(factoryInfo: ComponentFactoryDefintion, factoryKey: string) : string
 {
   // Get the factory name
-  const factoryName = factoryKey.split(path.sep).map(processName).join("") + "Factory"
+  const factoryName = factoryKey.split(path.posix.sep).map(processName).join("") + "Factory"
 
   // Get the components and sub-factories, sorted by key to minimize changes between runs
   const components = [...factoryInfo.entries].sort((a,b) => { return a.key < b.key ? -1 : a.key > b.key ? 1 : 0 })


### PR DESCRIPTION
Minimal fix for Windows import path where a backslash was included and treated as an escape character.

Also fix issue where factory key split was failing due to split on wrong character since upstream code explicitly uses `path.posix` while the `factoryKey.split` did not.

| Before | After |
| --- | --- |
| <img width="789" height="508" alt="image" src="https://github.com/user-attachments/assets/59c0adb2-0fcc-4df8-a4b9-62035ac3dec2" /> | <img width="697" height="417" alt="image" src="https://github.com/user-attachments/assets/8a6e5916-f705-4042-acc6-32641bb2fce3" /> |
