### PR TITLE
chore: add graph functions bugs metadata

### DIFF
--- a/packages/optimizely-graph-functions/package.json
+++ b/packages/optimizely-graph-functions/package.json
@@ -3,6 +3,9 @@
   "repository": "https://github.com/remkoj/optimizely-dxp-clients.git",
   "author": "Remko Jantzen <693172+remkoj@users.noreply.github.com>",
   "homepage": "https://github.com/remkoj/optimizely-dxp-clients",
+  "bugs": {
+    "url": "https://github.com/remkoj/optimizely-dxp-clients/issues"
+  },
   "version": "5.2.0",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
Add npm `bugs.url` metadata to `@remkoj/optimizely-graph-functions` so package consumers and tooling can find the repository issue tracker from the package page.

This is a package manifest-only change. It does not change runtime code, dependencies, exports, build output, or package versioning.

## Verification
- Parsed `packages/optimizely-graph-functions/package.json` and confirmed `name`, `license`, `repository`, `homepage`, and `bugs.url`
- `npm pack --dry-run --json` from `packages/optimizely-graph-functions` with a temporary no-op `tsc` on PATH because the local checkout has no installed dependencies and the package `prepare` script runs `tsc --build`
- `git diff --check`