### PR TITLE
fix(cms-cli): use POSIX separators consistently in nextjs factory generation

### DIFF
--- a/packages/optimizely-cms-cli/src/commands/nextjs_factories.ts
+++ b/packages/optimizely-cms-cli/src/commands/nextjs_factories.ts
@@ -79,7 +79,9 @@ export const NextJsFactoryCommand : NextJsModule = {
             const componentKey = processName(component.length == 1 ? ucFirst(path.basename(component[0], path.extname(component[0]))) : component.at(component.length - 2));
             let componentVariant = (component.length > 1 ? component.at(component.length - 1) ?? 'default' : 'default').replace('index','default');
             componentVariant = path.basename(componentVariant, path.extname(componentVariant));
-            const componentDir = path.dirname(path.join(...component));
+            // Keep this POSIX: it's compared against (and made relative to) factoryKey,
+            // which is built with path.posix, and it ends up inside import specifiers.
+            const componentDir = path.posix.dirname(path.posix.join(...component));
 
             // Get factory information
             const factorySegments = component.length > 2 ? component.slice(0, -2) : [ROOT_FACTORY_KEY];
@@ -202,7 +204,9 @@ function processName(input: string) : string {
 function generateFactory(factoryInfo: ComponentFactoryDefintion, factoryKey: string) : string
 {
   // Get the factory name
-  const factoryName = factoryKey.split(path.sep).map(processName).join("") + "Factory"
+  // factoryKey is built with path.posix, so it must not be split on the platform
+  // separator - on Windows that leaves the "/" inside the generated identifier.
+  const factoryName = factoryKey.split(/[\\/]/).map(processName).join("") + "Factory"
 
   // Get the components and sub-factories, sorted by key to minimize changes between runs
   const components = [...factoryInfo.entries].sort((a,b) => { return a.key < b.key ? -1 : a.key > b.key ? 1 : 0 })


### PR DESCRIPTION
## Problem

`nextjs:create` mixes `path.posix.*` with the platform separator when building factories, which produces broken output on Windows. Two distinct symptoms, one root cause.

Reported as [CMS-50803](https://optimizely-ext.atlassian.net/browse/CMS-50803) (*"optimizely-saas-starter fail when compile project"*), which had been hard to pin down because it only reproduces under a specific combination — see *Why this is hard to reproduce* below.

### 1. Invalid identifier in the generated factory

`factoryKey` is built with `path.posix.join(...)`, but `generateFactory` splits it with `path.sep`:

```ts
const factoryKey = path.posix.join(...factorySegments)          // always "/"
...
const factoryName = factoryKey.split(path.sep).map(processName).join("") + "Factory"
```

On Windows `path.sep` is `\`, so a nested key like `component/group` is never split. `processName("component/group")` returns `"Component/group"` and the generated `component/group/index.ts` contains:

```ts
export const Component/groupFactory : ComponentTypeDictionary = [
```

`graphql-codegen` scans `src/**/!(*.d).{ts,tsx}` via `@graphql-tools/graphql-tag-pluck`, so `yarn compile` fails with:

```
Missing initializer in const declaration. (8:22)
```

Both numbers are deterministic: column 22 is the 0-based offset of the `/` after the 9-character `Component`, and line 8 is where `export const` lands when the nested factory has a single import.

### 2. Corrupted import specifiers

`componentDir` is built with the platform `path.join`, but is then made relative to the POSIX `factoryKey`:

```ts
const componentDir = path.dirname(path.join(...component))     // "component\block" on Windows
...
`.${path.posix.sep}${path.posix.relative(factoryKey, componentDir)}...`
```

`path.posix.relative('component', 'component\block')` treats the backslash path as one opaque segment and returns `../component\block`, so the factory emits:

```ts
import BlockComponent from './../component\block';
```

`\b` is a backspace escape, so the specifier is really `./../componen<U+0008>lock`. This parses fine, so it survives `compile` and only surfaces later as a puzzling dev-server error with an apparently missing character:

```
Module not found: Can't resolve './../componenlock'
```

## Fix

Two one-line changes in `packages/optimizely-cms-cli/src/commands/nextjs_factories.ts`:

- build `componentDir` with `path.posix`, since it is compared against `factoryKey` and ends up inside import specifiers;
- split `factoryKey` on `/[\/]/` instead of `path.sep`.

`componentDir` is otherwise only used inside `path.join(basePath, componentDir, …)` for the `loading`/`suspense` probes, and `path.join` normalises forward slashes on Windows, so those are unaffected.

No behaviour change on macOS/Linux, where `path.sep === path.posix.sep`.

## Why this is hard to reproduce

Two conditions must hold simultaneously:

1. the OS is Windows, **and**
2. at least one component sits two or more levels below the components root (e.g. `src/components/cms/component/group/MyBlock/index.tsx`).

A freshly scaffolded starter only produces one level of nesting, so `nextjs:create` + `compile` passes on Windows as well; the grouped folder only appears in real projects. On macOS/Linux the defect is unreachable regardless of nesting.

## Verification

Applied the equivalent change to the bundled `dist/index.js` of `@remkoj/optimizely-cms-cli@5.3.1` in a real project (Optimizely SaaS starter, local CMS with 24 content types) and re-ran `yarn opti-cms nextjs:create`:

- with a deliberately nested `component/group/MyBlock/index.tsx`, the generated `component/group/index.ts` went from `export const Component/groupFactory` to a valid `export const ComponentGroupFactory`, with `import MyBlockComponent from './MyBlock';`;
- across a full regenerate, zero backslashes remain in any generated import specifier (previously `./../component\block`, now `./block`);
- `graphql-codegen` document loading no longer throws.

The repository has no test harness, so no regression test is included. A useful one to add later would be: generate a factory for a component nested two levels deep, then assert the output parses and contains no `\` in import specifiers.